### PR TITLE
fix(ui,audio): fit home screen on any screen + crash hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,10 @@ jobs:
       
   build-test-windows:
     name: Build Test Windows
-    runs-on: windows-latest
+    # Pinned to windows-2022: windows-latest (now the windows-2025 image) breaks
+    # Flutter's Visual Studio detection, which then falls back to the
+    # "Visual Studio 16 2019" CMake generator and fails (VS 2019 is gone).
+    runs-on: windows-2022
     needs: test
     
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,10 @@ jobs:
         
   build-windows-x64:
     name: Build Windows x64
-    runs-on: windows-latest
+    # Pinned to windows-2022: windows-latest (now the windows-2025 image) breaks
+    # Flutter's Visual Studio detection, which then falls back to the
+    # "Visual Studio 16 2019" CMake generator and fails (VS 2019 is gone).
+    runs-on: windows-2022
     
     steps:
     - name: Checkout repository

--- a/lib/models/current_track.dart
+++ b/lib/models/current_track.dart
@@ -17,12 +17,12 @@ class CurrentTrack {
 
   factory CurrentTrack.fromJson(Map<String, dynamic> json) {
     return CurrentTrack(
-      artist: json['artist'] ?? '',
-      title: json['title'] ?? '',
-      uuid: json['uuid'] ?? '',
-      duration: json['duration'] ?? 0,
-      isMusic: json['is_music'] ?? false,
-      url: json['url'] ?? '',
+      artist: json['artist']?.toString() ?? '',
+      title: json['title']?.toString() ?? '',
+      uuid: json['uuid']?.toString() ?? '',
+      duration: json['duration'] is num ? (json['duration'] as num).toInt() : 0,
+      isMusic: json['is_music'] == true,
+      url: json['url']?.toString() ?? '',
     );
   }
 

--- a/lib/models/stream_config.dart
+++ b/lib/models/stream_config.dart
@@ -41,16 +41,16 @@ class StreamConfig {
     final hlsUrl = json['stream_hls_url'];
     final streamUrl = (hlsUrl is String && hlsUrl.isNotEmpty)
         ? hlsUrl
-        : (json['stream_url'] ?? '');
-    final streamUuid = json['stream_uuid'] as String?;
+        : (json['stream_url']?.toString() ?? '');
+    final streamUuid = json['stream_uuid']?.toString();
     final volume = _parseVolume(json['volume']);
     final parsedMusicVolume = _parseOptionalVolume(json['music_volume']);
-    final title = json['title'];
-    final description = json['description'];
+    final title = json['title']?.toString();
+    final description = json['description']?.toString();
 
     CurrentTrack? current;
-    if (json['current'] != null) {
-      current = CurrentTrack.fromJson(json['current']);
+    if (json['current'] is Map<String, dynamic>) {
+      current = CurrentTrack.fromJson(json['current'] as Map<String, dynamic>);
     }
 
     // TODO: DO NOT REMOVE!!!

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -458,8 +458,10 @@ class _HomeScreenState extends State<HomeScreen> {
       return;
     }
 
-    Logger.info(
-        'HomeScreen: Connecting with code: ${_currentCode.substring(0, 2)}****');
+    final maskedCode = _currentCode.length >= 2
+        ? '${_currentCode.substring(0, 2)}****'
+        : '****';
+    Logger.info('HomeScreen: Connecting with code: $maskedCode');
 
     final result = await _radioService.connect(_currentCode);
     result.fold(
@@ -1163,311 +1165,337 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   Widget _buildMainContent(Widget? visualizerButton) {
-    return Padding(
-      padding: const EdgeInsets.all(12.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          // TIP Card - compact version
-          Card(
-            color: Colors.grey[300],
-            child: InkWell(
-              onTap: _launchPersonalCabinet,
-              borderRadius: BorderRadius.circular(8),
+    return SafeArea(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return SingleChildScrollView(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
               child: Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Row(
+                padding: const EdgeInsets.all(12.0),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    Icon(
-                      Icons.lightbulb_outline,
-                      color: TunioColors.primary,
-                      size: 18,
-                    ),
-                    const SizedBox(width: 6),
-                    Expanded(
-                      child: Text(
-                        'TIP: Get PIN code at cp.tunio.ai/spot-links',
-                        style: TextStyle(
-                          color: Colors.black87,
-                          fontSize: 12,
-                          fontWeight: FontWeight.w500,
+                    // TIP Card - compact version
+                    Card(
+                      color: Colors.grey[300],
+                      child: InkWell(
+                        onTap: _launchPersonalCabinet,
+                        borderRadius: BorderRadius.circular(8),
+                        child: Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Row(
+                            children: [
+                              Icon(
+                                Icons.lightbulb_outline,
+                                color: TunioColors.primary,
+                                size: 18,
+                              ),
+                              const SizedBox(width: 6),
+                              Expanded(
+                                child: Text(
+                                  'TIP: Get PIN code at cp.tunio.ai/spot-links',
+                                  style: TextStyle(
+                                    color: Colors.black87,
+                                    fontSize: 12,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                              ),
+                              Icon(
+                                Icons.open_in_new,
+                                color: TunioColors.primary,
+                                size: 14,
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     ),
-                    Icon(
-                      Icons.open_in_new,
-                      color: TunioColors.primary,
-                      size: 14,
+                    const SizedBox(height: 12),
+
+                    // Connection Card - compact version
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(12.0),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          children: [
+                            CodeInputWidget(
+                              value: _currentCode,
+                              onChanged: (code) {
+                                setState(() {
+                                  _currentCode = code;
+                                  _isUserEditingCode =
+                                      true; // Mark that user is editing
+                                });
+                              },
+                              onTap: () {
+                                setState(() {
+                                  _isUserEditingCode =
+                                      true; // Mark that user is editing
+                                });
+                              },
+                              onSubmitted: () {
+                                if (!_radioState.isConnecting) {
+                                  _connect();
+                                }
+                              },
+                              enabled: !_radioState.isConnecting,
+                              focusNode: _codeFocusNode,
+                            ),
+                            const SizedBox(height: 12),
+                            Focus(
+                              focusNode: _connectButtonFocusNode,
+                              child: ElevatedButton.icon(
+                                onPressed:
+                                    _radioState.isConnecting ? null : _connect,
+                                icon: _radioState.isConnecting
+                                    ? const SizedBox(
+                                        width: 16,
+                                        height: 16,
+                                        child: CircularProgressIndicator(
+                                          strokeWidth: 2,
+                                          valueColor:
+                                              AlwaysStoppedAnimation<Color>(
+                                                  Colors.white),
+                                        ),
+                                      )
+                                    : Icon(_radioState.isConnected
+                                        ? Icons.sync
+                                        : Icons.login),
+                                label: Text(_radioState.isConnecting
+                                    ? 'Connecting...'
+                                    : (_radioState.isConnected
+                                        ? 'Change PIN & Reconnect'
+                                        : 'Connect')),
+                                style: ElevatedButton.styleFrom(
+                                  padding:
+                                      const EdgeInsets.symmetric(vertical: 10),
+                                  backgroundColor: _radioState.isConnecting
+                                      ? TunioColors.primary
+                                          .withValues(alpha: 0.7)
+                                      : TunioColors.primary,
+                                  foregroundColor: Colors.white,
+                                  disabledBackgroundColor: TunioColors.primary
+                                      .withValues(alpha: 0.7),
+                                  disabledForegroundColor: Colors.white,
+                                  side: _connectButtonFocusNode.hasFocus
+                                      ? BorderSide(
+                                          color: TunioColors.primary, width: 2)
+                                      : null,
+                                ),
+                              ),
+                            ),
+
+                            // Show connected status if connected
+                            if (_radioState.isConnected)
+                              Container(
+                                margin: const EdgeInsets.only(top: 8),
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 12, vertical: 8),
+                                decoration: BoxDecoration(
+                                  color: Colors.green.withValues(alpha: 0.1),
+                                  borderRadius: BorderRadius.circular(6),
+                                  border: Border.all(
+                                    color: Colors.green.withValues(alpha: 0.3),
+                                  ),
+                                ),
+                                child: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    const Icon(Icons.check_circle,
+                                        color: Colors.green, size: 16),
+                                    const SizedBox(width: 6),
+                                    Text(
+                                      'Connected - Running in Background',
+                                      style: TextStyle(
+                                        color: Colors.green,
+                                        fontSize: 12,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
                     ),
+                    const SizedBox(height: 12),
+
+                    // Player Card (compact layout)
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: Column(
+                          children: [
+                            Text(
+                              _radioState.config?.title ?? '',
+                              style: const TextStyle(
+                                fontSize: 18,
+                                fontWeight: FontWeight.bold,
+                              ),
+                            ),
+                            const SizedBox(height: 16),
+                            FocusTraversalGroup(
+                              policy: WidgetOrderTraversalPolicy(),
+                              child: Row(
+                                children: [
+                                  // Circular play/pause button
+                                  FocusTraversalOrder(
+                                    order: const NumericFocusOrder(1),
+                                    child: Focus(
+                                      focusNode: _playButtonFocusNode,
+                                      child: ElevatedButton(
+                                        onPressed: _radioState.isConnecting
+                                            ? null
+                                            : () => _onPlayButtonPressed(),
+                                        style: ElevatedButton.styleFrom(
+                                          shape: const CircleBorder(),
+                                          padding: const EdgeInsets.all(16),
+                                          side: _playButtonFocusNode.hasFocus
+                                              ? BorderSide(
+                                                  color: TunioColors.primary,
+                                                  width: 3)
+                                              : null,
+                                        ),
+                                        child: Icon(
+                                          _getPlayPauseIcon(),
+                                          size: 32,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                  const SizedBox(width: 12),
+
+                                  if (visualizerButton != null) ...[
+                                    FocusTraversalOrder(
+                                      order: const NumericFocusOrder(2),
+                                      child: visualizerButton,
+                                    ),
+                                    const SizedBox(width: 12),
+                                  ],
+
+                                  // Compact indicators wrap to multiple rows on small screens
+                                  Expanded(
+                                    child: _buildCompactIndicators(),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+
+                    // Status indicator and metrics
+                    Card(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16.0),
+                        child: LayoutBuilder(
+                          builder: (context, constraints) {
+                            final isMobile = constraints.maxWidth < 600;
+
+                            if (isMobile) {
+                              // Mobile layout: Column (status above, metrics below)
+                              return Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  // Status indicator
+                                  StatusIndicator(
+                                    audioState: _getAudioState() ??
+                                        const AudioStateIdle(),
+                                    isConnected: _radioState.isConnected,
+                                    statusMessage: _getStatusText(),
+                                  ),
+                                  const SizedBox(height: 16),
+
+                                  // Metrics chips in wrapped layout
+                                  _buildMetricsChips(),
+                                ],
+                              );
+                            } else {
+                              // Tablet/Desktop layout: Row (status left, metrics right)
+                              return Row(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
+                                children: [
+                                  // Status indicator (left side) - takes only needed space
+                                  StatusIndicator(
+                                    audioState: _getAudioState() ??
+                                        const AudioStateIdle(),
+                                    isConnected: _radioState.isConnected,
+                                    statusMessage: _getStatusText(),
+                                  ),
+
+                                  // Metrics chips (right side) - aligned to right
+                                  _buildMetricsChips(),
+                                ],
+                              );
+                            }
+                          },
+                        ),
+                      ),
+                    ),
+
+                    // Diagnostic indicator at the bottom
+                    if (_radioState.isConnecting ||
+                        _radioState is RadioStateError)
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                            vertical: 4, horizontal: 8),
+                        margin: const EdgeInsets.only(top: 8),
+                        decoration: BoxDecoration(
+                          color: _radioState.isConnecting
+                              ? Colors.blue.withValues(alpha: 0.1)
+                              : Colors.red.withValues(alpha: 0.1),
+                          borderRadius: BorderRadius.circular(8),
+                          border: Border.all(
+                            color: _radioState.isConnecting
+                                ? Colors.blue.withValues(alpha: 0.3)
+                                : Colors.red.withValues(alpha: 0.3),
+                          ),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            if (_radioState.isConnecting)
+                              SizedBox(
+                                width: 12,
+                                height: 12,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  valueColor: AlwaysStoppedAnimation<Color>(
+                                      Colors.blue),
+                                ),
+                              )
+                            else
+                              Icon(Icons.error_outline,
+                                  size: 12, color: Colors.red),
+                            const SizedBox(width: 6),
+                            Text(
+                              _getDiagnosticText(),
+                              style: TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.w500,
+                                color: _radioState.isConnecting
+                                    ? Colors.blue
+                                    : Colors.red,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
                   ],
                 ),
               ),
             ),
-          ),
-          const SizedBox(height: 12),
-
-          // Connection Card - compact version
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(12.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: [
-                  CodeInputWidget(
-                    value: _currentCode,
-                    onChanged: (code) {
-                      setState(() {
-                        _currentCode = code;
-                        _isUserEditingCode = true; // Mark that user is editing
-                      });
-                    },
-                    onTap: () {
-                      setState(() {
-                        _isUserEditingCode = true; // Mark that user is editing
-                      });
-                    },
-                    onSubmitted: () {
-                      if (!_radioState.isConnecting) {
-                        _connect();
-                      }
-                    },
-                    enabled: !_radioState.isConnecting,
-                    focusNode: _codeFocusNode,
-                  ),
-                  const SizedBox(height: 12),
-                  Focus(
-                    focusNode: _connectButtonFocusNode,
-                    child: ElevatedButton.icon(
-                      onPressed: _radioState.isConnecting ? null : _connect,
-                      icon: _radioState.isConnecting
-                          ? const SizedBox(
-                              width: 16,
-                              height: 16,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                valueColor:
-                                    AlwaysStoppedAnimation<Color>(Colors.white),
-                              ),
-                            )
-                          : Icon(_radioState.isConnected
-                              ? Icons.sync
-                              : Icons.login),
-                      label: Text(_radioState.isConnecting
-                          ? 'Connecting...'
-                          : (_radioState.isConnected
-                              ? 'Change PIN & Reconnect'
-                              : 'Connect')),
-                      style: ElevatedButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(vertical: 10),
-                        backgroundColor: _radioState.isConnecting
-                            ? TunioColors.primary.withValues(alpha: 0.7)
-                            : TunioColors.primary,
-                        foregroundColor: Colors.white,
-                        disabledBackgroundColor:
-                            TunioColors.primary.withValues(alpha: 0.7),
-                        disabledForegroundColor: Colors.white,
-                        side: _connectButtonFocusNode.hasFocus
-                            ? BorderSide(color: TunioColors.primary, width: 2)
-                            : null,
-                      ),
-                    ),
-                  ),
-
-                  // Show connected status if connected
-                  if (_radioState.isConnected)
-                    Container(
-                      margin: const EdgeInsets.only(top: 8),
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 12, vertical: 8),
-                      decoration: BoxDecoration(
-                        color: Colors.green.withValues(alpha: 0.1),
-                        borderRadius: BorderRadius.circular(6),
-                        border: Border.all(
-                          color: Colors.green.withValues(alpha: 0.3),
-                        ),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          const Icon(Icons.check_circle,
-                              color: Colors.green, size: 16),
-                          const SizedBox(width: 6),
-                          Text(
-                            'Connected - Running in Background',
-                            style: TextStyle(
-                              color: Colors.green,
-                              fontSize: 12,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(height: 12),
-
-          // Player Card (compact layout)
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                children: [
-                  Text(
-                    _radioState.config?.title ?? '',
-                    style: const TextStyle(
-                      fontSize: 18,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  const SizedBox(height: 16),
-                  FocusTraversalGroup(
-                    policy: WidgetOrderTraversalPolicy(),
-                    child: Row(
-                      children: [
-                        // Circular play/pause button
-                        FocusTraversalOrder(
-                          order: const NumericFocusOrder(1),
-                          child: Focus(
-                            focusNode: _playButtonFocusNode,
-                            child: ElevatedButton(
-                              onPressed: _radioState.isConnecting
-                                  ? null
-                                  : () => _onPlayButtonPressed(),
-                              style: ElevatedButton.styleFrom(
-                                shape: const CircleBorder(),
-                                padding: const EdgeInsets.all(16),
-                                side: _playButtonFocusNode.hasFocus
-                                    ? BorderSide(
-                                        color: TunioColors.primary, width: 3)
-                                    : null,
-                              ),
-                              child: Icon(
-                                _getPlayPauseIcon(),
-                                size: 32,
-                              ),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(width: 12),
-
-                        if (visualizerButton != null) ...[
-                          FocusTraversalOrder(
-                            order: const NumericFocusOrder(2),
-                            child: visualizerButton,
-                          ),
-                          const SizedBox(width: 12),
-                        ],
-
-                        // Compact indicators wrap to multiple rows on small screens
-                        Expanded(
-                          child: _buildCompactIndicators(),
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-          const SizedBox(height: 12),
-
-          // Status indicator and metrics
-          Card(
-            child: Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: LayoutBuilder(
-                builder: (context, constraints) {
-                  final isMobile = constraints.maxWidth < 600;
-
-                  if (isMobile) {
-                    // Mobile layout: Column (status above, metrics below)
-                    return Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        // Status indicator
-                        StatusIndicator(
-                          audioState:
-                              _getAudioState() ?? const AudioStateIdle(),
-                          isConnected: _radioState.isConnected,
-                          statusMessage: _getStatusText(),
-                        ),
-                        const SizedBox(height: 16),
-
-                        // Metrics chips in wrapped layout
-                        _buildMetricsChips(),
-                      ],
-                    );
-                  } else {
-                    // Tablet/Desktop layout: Row (status left, metrics right)
-                    return Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        // Status indicator (left side) - takes only needed space
-                        StatusIndicator(
-                          audioState:
-                              _getAudioState() ?? const AudioStateIdle(),
-                          isConnected: _radioState.isConnected,
-                          statusMessage: _getStatusText(),
-                        ),
-
-                        // Metrics chips (right side) - aligned to right
-                        _buildMetricsChips(),
-                      ],
-                    );
-                  }
-                },
-              ),
-            ),
-          ),
-
-          // Diagnostic indicator at the bottom
-          if (_radioState.isConnecting || _radioState is RadioStateError)
-            Container(
-              padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
-              margin: const EdgeInsets.only(top: 8),
-              decoration: BoxDecoration(
-                color: _radioState.isConnecting
-                    ? Colors.blue.withValues(alpha: 0.1)
-                    : Colors.red.withValues(alpha: 0.1),
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(
-                  color: _radioState.isConnecting
-                      ? Colors.blue.withValues(alpha: 0.3)
-                      : Colors.red.withValues(alpha: 0.3),
-                ),
-              ),
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  if (_radioState.isConnecting)
-                    SizedBox(
-                      width: 12,
-                      height: 12,
-                      child: CircularProgressIndicator(
-                        strokeWidth: 2,
-                        valueColor: AlwaysStoppedAnimation<Color>(Colors.blue),
-                      ),
-                    )
-                  else
-                    Icon(Icons.error_outline, size: 12, color: Colors.red),
-                  const SizedBox(width: 6),
-                  Text(
-                    _getDiagnosticText(),
-                    style: TextStyle(
-                      fontSize: 10,
-                      fontWeight: FontWeight.w500,
-                      color:
-                          _radioState.isConnecting ? Colors.blue : Colors.red,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-        ],
+          );
+        },
       ),
     );
   }

--- a/lib/services/audio_service.dart
+++ b/lib/services/audio_service.dart
@@ -412,6 +412,7 @@ final class EnhancedAudioService implements IAudioService {
         isConnected: hasConnection,
         type: connectionType,
       );
+      if (_isDisposed) return;
       _networkController.add(_networkState);
 
       Logger.info(
@@ -422,6 +423,7 @@ final class EnhancedAudioService implements IAudioService {
         isConnected: true,
         type: ConnectionType.unknown,
       );
+      if (_isDisposed) return;
       _networkController.add(_networkState);
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: tunio_radio_player
 description: "A Flutter radio streaming application with auto-start functionality"
 publish_to: 'none'
 
-version: 1.4.0+25
+version: 1.5.0+26
 
 environment:
   sdk: '>=3.5.0 <4.0.0'


### PR DESCRIPTION
Home screen layout:
- Wrap body in SafeArea + LayoutBuilder + SingleChildScrollView + ConstrainedBox(minHeight) so content fills the viewport, stays clear of system bars, and scrolls instead of clipping when it cannot fit.
- Center the card group with normal 12px gaps (replaces the spaceBetween stretch that pushed the bottom card under the navigation bar).

Crash hardening:
- home_screen: mask PIN safely in logs (RangeError on a 1-digit code).
- CurrentTrack/StreamConfig.fromJson: tolerate unexpected JSON value types (number/string/object) instead of throwing TypeError.
- AudioService: guard _networkController.add against add-after-close during the delayed initial network check (dispose race).

Bump version 1.4.0+25 -> 1.5.0+26.